### PR TITLE
address clang22 build breakage, 

### DIFF
--- a/Source/TagLibrary/GSMarkupTagForm.m
+++ b/Source/TagLibrary/GSMarkupTagForm.m
@@ -101,7 +101,7 @@
 	/* The following call will cause the item to load all
 	 * additional attributes into the platform object.
 	 */
-	cell = [item initPlatformObject: cell];
+	cell = (id)[item initPlatformObject: cell];
 	[item setPlatformObject: cell];
       }
   }


### PR DESCRIPTION
methods starting with init are assumed to return (instancetype) which clang22 absolutely doesn't like